### PR TITLE
Resources updates

### DIFF
--- a/app/components/ResourceCard.jsx
+++ b/app/components/ResourceCard.jsx
@@ -96,7 +96,7 @@ export default class extends Component {
           <CardMedia style={{padding: 15}}>
             <img src={this.state.image ? this.state.image : '/default-placeholder.jpg'} className="resource-img" />
           </CardMedia>
-          <CardText expandable={true}>
+          <CardText expandable={true} expanded={true}>
             {this.state.description}
           </CardText>
           <CardActions expandable={true}>

--- a/app/components/ResourceCard.jsx
+++ b/app/components/ResourceCard.jsx
@@ -87,7 +87,7 @@ export default class extends Component {
     // do we maybe want a ternary that either renders a text preview or the full description????
     return (
       <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
-        <Card className="resource-card" style={{width: 250}}>
+        <Card className="resource-card" style={{width: 250}} initiallyExpanded={true}>
           <CardHeader
             title={this.state.title}
             actAsExpander={true}
@@ -96,7 +96,7 @@ export default class extends Component {
           <CardMedia style={{padding: 15}}>
             <img src={this.state.image ? this.state.image : '/default-placeholder.jpg'} className="resource-img" />
           </CardMedia>
-          <CardText expandable={true} expanded={true}>
+          <CardText expandable={true}>
             {this.state.description}
           </CardText>
           <CardActions expandable={true}>
@@ -107,10 +107,12 @@ export default class extends Component {
               primary={true}
               icon={<ContentLink />}
             />
+            {/*
             <FlatButton
               label="Edit resource"
               icon={<ContentEdit />}
             />
+            */}
           </CardActions>
         </Card>
       </MuiThemeProvider>

--- a/app/components/ResourceForm.jsx
+++ b/app/components/ResourceForm.jsx
@@ -63,6 +63,7 @@ export default class extends Component {
         resourcesRef.child(key).set(response)
       }
     })
+    this.setState({url: ''})
   }
 
   render() {
@@ -74,11 +75,14 @@ export default class extends Component {
               floatingLabelText='Add a new resource:'
               floatingLabelShrinkStyle={{'fontSize': 20}}
               onChange={this.handleChange}
+              value={this.state.url}
               id='url'
             />
+          {this.state.url &&
           <IconButton type="submit" tooltip="click to add" touch={true} tooltipPosition="top-center">
             <ContentAdd />
           </IconButton>
+          }
         </form>
       </MuiThemeProvider>
     )


### PR DESCRIPTION
removed "edit resource" button (for now!), made cards initially expanded, and made button to add resources only show when text field has something in it (in the future, validate URL?)  Closes #177, closes #178, closes #179 